### PR TITLE
Fix shortread_8.scss styles

### DIFF
--- a/src/magne_b6/_scss/_layout.scss
+++ b/src/magne_b6/_scss/_layout.scss
@@ -1,4 +1,4 @@
-@use '../common.scss' as *;
+@use '../../common.scss' as *;
 
 $light-blue: #d7e9ff;
 $dark-blue: #001887;

--- a/src/magne_b6/_scss/shortread_8.scss
+++ b/src/magne_b6/_scss/shortread_8.scss
@@ -1,0 +1,192 @@
+@use '../../common.scss' as *;
+@use '_layout' as *;
+
+body.shortread_8 {
+  background-color: $light-blue;
+  
+  .pregnancy-header {
+
+    .pregnancy-header-inner {
+      padding: 40rem 0;
+    }
+    
+    .description {
+      margin-top: 24rem;
+    }
+
+    .mg-benefits {
+      display: flex;
+      gap: 20rem;
+      align-items: flex-start;
+      @include mobile {
+        flex-direction: column;
+        gap: 20rem;
+      }
+      
+      .left-content {
+        flex: 1;
+        
+        .benefits-title {
+          font-size: 20rem;
+          font-weight: 600;
+          color: $dark-blue;
+          margin-bottom: 16rem;
+          @include mobile {
+            font-size: 18rem;
+          }
+        }
+        
+        .benefits-list {
+          .benefit-item {
+            font-size: 16rem;
+            line-height: 1.4;
+            margin-bottom: 8rem;
+            @include mobile {
+              font-size: 15rem;
+            }
+          }
+        }
+      }
+      
+      .right-content {
+        flex-shrink: 0;
+        img {
+          width: 300rem;
+          height: auto;
+          @include mobile {
+            width: 200rem;
+          }
+        }
+      }
+    }
+  }
+
+  .pregnancy-symptoms {
+    .inner {
+      display: flex;
+      gap: 40rem;
+      padding: 30rem;
+      @include mobile {
+        flex-direction: column;
+        gap: 30rem;
+      }
+    }
+    
+    .symptoms-section {
+      flex: 1;
+      
+      .symptoms-title {
+        font-size: 24rem;
+        font-weight: 600;
+        color: $dark-blue;
+        margin-bottom: 20rem;
+        @include mobile {
+          font-size: 20rem;
+        }
+      }
+      
+      .symptoms-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 16rem;
+        @include mobile {
+          grid-template-columns: 1fr;
+          gap: 12rem;
+        }
+        
+        .symptom-item {
+          display: flex;
+          align-items: center;
+          gap: 12rem;
+          
+          .icon-wrapper {
+            width: 50rem;
+            height: 50rem;
+            flex-shrink: 0;
+            
+            .icon-circle {
+              width: 100%;
+              height: 100%;
+              background: $base-blue;
+              border-radius: 50%;
+              display: flex;
+              align-items: center;
+              justify-content: center;
+              font-size: 24rem;
+            }
+            
+            img {
+              width: 100%;
+              height: 100%;
+            }
+          }
+          
+          .symptom-text {
+            font-size: 1rem;
+            line-height: 1.3;
+          }
+        }
+      }
+    }
+    
+    .stats-section {
+      flex-shrink: 0;
+      
+      .stats-box {
+        background: linear-gradient(135deg, #E3F2FD 0%, #BBDEFB 100%);
+        border-radius: 20rem;
+        padding: 24rem;
+        text-align: center;
+        position: relative;
+        box-shadow: 0 4rem 20rem rgba(0, 24, 135, 0.1);
+        border: 2rem solid rgba(175, 190, 255, 0.3);
+        
+        .stats-header {
+          font-size: 15rem;
+          color: $dark-blue;
+          margin-bottom: 20rem;
+          line-height: 1.4;
+          font-weight: 500;
+        }
+        
+        .stats-main {
+          .big-number {
+            font-size: 84rem;
+            font-weight: 700;
+            color: $dark-blue;
+            line-height: 1;
+            margin-bottom: 8rem;
+          }
+          
+          .stats-text {
+            font-size: 20rem;
+            color: $dark-blue;
+            font-weight: 600;
+            line-height: 1.3;
+          }
+        }
+        
+        .mg-elements {
+          display: flex;
+          justify-content: center;
+          gap: 16rem;
+          margin-top: 20rem;
+          
+          .mg-element {
+            width: 56rem;
+            height: 56rem;
+            background: rgba(255, 255, 255, 0.9);
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 18rem;
+            font-weight: 700;
+            color: $dark-blue;
+            box-shadow: 0 2rem 8rem rgba(0, 24, 135, 0.15);
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/magne_b6/shortread_8.pug
+++ b/src/magne_b6/shortread_8.pug
@@ -1,0 +1,93 @@
+extends layout.pug
+
+prepend body
+	- var type = 'shortread_8'
+
+block content
+
+	section.pregnancy-header
+		.container
+			.pregnancy-header-inner
+				.block_title
+					| Магний и беременность
+				.description
+					| Важность магния для здоровья матери и развития плода
+
+				.mg-benefits
+					.left-content
+						.benefits-title
+							| Преимущества магния при беременности:
+						.benefits-list
+							.benefit-item
+								| Поддержка нормального развития плода
+							.benefit-item
+								| Снижение риска преэклампсии
+							.benefit-item
+								| Улучшение качества сна
+							.benefit-item
+								| Снижение мышечных судорог
+							.benefit-item
+								| Поддержка нервной системы
+					.right-content
+						img(src="./img/b4.png" alt="Беременная женщина")
+
+	section.pregnancy-symptoms
+		.container
+			.inner
+				.symptoms-section
+					.symptoms-title
+						| Симптомы дефицита магния при беременности
+					.symptoms-grid
+						.symptom-item
+							.icon-wrapper
+								.icon-circle
+									| 🤱
+							.symptom-text
+								| Мышечные судороги
+						.symptom-item
+							.icon-wrapper
+								.icon-circle
+									| 😴
+							.symptom-text
+								| Нарушения сна
+						.symptom-item
+							.icon-wrapper
+								.icon-circle
+									| 💓
+							.symptom-text
+								| Учащенное сердцебиение
+						.symptom-item
+							.icon-wrapper
+								.icon-circle
+									| 😣
+							.symptom-text
+								| Головные боли
+						.symptom-item
+							.icon-wrapper
+								.icon-circle
+									| 🤢
+							.symptom-text
+								| Тошнота и рвота
+						.symptom-item
+							.icon-wrapper
+								.icon-circle
+									| 😰
+							.symptom-text
+								| Повышенная тревожность
+
+				.stats-section
+					.stats-box
+						.stats-header
+							| Потребность в магнии увеличивается во время беременности
+						.stats-main
+							.big-number
+								| 350-400
+							.stats-text
+								| мг/сутки
+						.mg-elements
+							.mg-element
+								| Mg²⁺
+							.mg-element
+								| +
+							.mg-element
+								| B₆

--- a/src/magne_b6/style.scss
+++ b/src/magne_b6/style.scss
@@ -1,3 +1,4 @@
 // @use '../common.scss' as *;
 @use '_scss/layout';
 @use '_scss/index';
+@use '_scss/shortread_8';


### PR DESCRIPTION
Add `shortread_8.scss` and `shortread_8.pug` files, fix SCSS import paths, and include new styles to enable `shortread_8` page styling.

---
<a href="https://cursor.com/background-agent?bcId=bc-a993a8f8-9591-4260-a6b8-23af2fbc5523">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a993a8f8-9591-4260-a6b8-23af2fbc5523">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

