### PR TITLE
Сверстать элементы как продолжение .populations

### DIFF
--- a/src/magne_b6/_scss/shortread_9.scss
+++ b/src/magne_b6/_scss/shortread_9.scss
@@ -1,0 +1,204 @@
+@use '../../common.scss' as *;
+
+$light-blue: #d7e9ff;
+$dark-blue: #001887;
+$light-purple: #afbeff;
+$base-blue: #CDE2FC;
+
+.populations {
+  padding: 60rem 0;
+  @include mobile {
+    padding: 40rem 0;
+  }
+
+  &__title {
+    font-size: 48rem;
+    font-weight: 700;
+    color: $dark-blue;
+    margin-bottom: 24rem;
+    @include mobile {
+      font-size: 32rem;
+      margin-bottom: 16rem;
+    }
+  }
+
+  &__subtitle {
+    font-size: 24rem;
+    font-weight: 600;
+    color: $dark-blue;
+    margin-bottom: 32rem;
+    @include mobile {
+      font-size: 18rem;
+      margin-bottom: 24rem;
+    }
+  }
+
+  &__discriptions {
+    font-size: 20rem;
+    line-height: 1.5;
+    margin-bottom: 32rem;
+    @include mobile {
+      font-size: 16rem;
+      margin-bottom: 24rem;
+    }
+  }
+
+  &__banner {
+    display: flex;
+    align-items: center;
+    background-color: $light-blue;
+    border-radius: 20rem;
+    padding: 40rem;
+    margin-bottom: 32rem;
+    @include mobile {
+      flex-direction: column;
+      padding: 24rem;
+      margin-bottom: 24rem;
+    }
+
+    &-left {
+      flex: 1;
+      margin-right: 40rem;
+      @include mobile {
+        margin-right: 0;
+        margin-bottom: 20rem;
+      }
+    }
+
+    &-text {
+      font-size: 20rem;
+      line-height: 1.5;
+      margin: 0;
+      @include mobile {
+        font-size: 16rem;
+      }
+    }
+
+    &-right {
+      flex-shrink: 0;
+      @include mobile {
+        width: 100%;
+        text-align: center;
+      }
+      
+      img {
+        max-width: 200rem;
+        height: auto;
+        @include mobile {
+          max-width: 150rem;
+        }
+      }
+    }
+  }
+
+  &__light-blue {
+    background-color: $light-blue;
+    border-radius: 20rem;
+    padding: 32rem;
+    margin-bottom: 32rem;
+    @include mobile {
+      padding: 24rem;
+      margin-bottom: 24rem;
+    }
+
+    &-text {
+      font-size: 20rem;
+      line-height: 1.5;
+      margin: 0;
+      @include mobile {
+        font-size: 16rem;
+      }
+    }
+  }
+
+  &__stats {
+    background: linear-gradient(135deg, #CDE2FC 0%, #AFBEFF 100%);
+    border-radius: 20rem;
+    padding: 0;
+    margin-bottom: 32rem;
+    overflow: hidden;
+    @include mobile {
+      margin-bottom: 24rem;
+    }
+
+    &-content {
+      display: flex;
+      align-items: center;
+      min-height: 200rem;
+      @include mobile {
+        flex-direction: column;
+        min-height: auto;
+      }
+    }
+
+    &-left {
+      flex-shrink: 0;
+      width: 280rem;
+      @include mobile {
+        width: 100%;
+        order: 2;
+        text-align: center;
+        padding: 20rem 0;
+      }
+      
+      img {
+        width: 100%;
+        height: auto;
+        display: block;
+        @include mobile {
+          max-width: 200rem;
+          margin: 0 auto;
+        }
+      }
+    }
+
+    &-right {
+      flex: 1;
+      padding: 40rem;
+      @include mobile {
+        padding: 24rem;
+        order: 1;
+      }
+    }
+
+    &-text {
+      font-size: 20rem;
+      line-height: 1.5;
+      color: $dark-blue;
+      margin-bottom: 24rem;
+      @include mobile {
+        font-size: 16rem;
+        margin-bottom: 20rem;
+      }
+    }
+
+    &-number {
+      display: flex;
+      align-items: baseline;
+      gap: 12rem;
+      @include mobile {
+        gap: 8rem;
+      }
+    }
+
+    &-main {
+      font-size: 72rem;
+      font-weight: 700;
+      color: $dark-blue;
+      line-height: 1;
+      @include mobile {
+        font-size: 48rem;
+      }
+    }
+
+    &-sub {
+      font-size: 36rem;
+      font-weight: 600;
+      color: $dark-blue;
+      line-height: 1;
+      @include mobile {
+        font-size: 24rem;
+      }
+    }
+  }
+}

--- a/src/magne_b6/shortread_9.pug
+++ b/src/magne_b6/shortread_9.pug
@@ -1,0 +1,45 @@
+extends layout.pug
+
+prepend body
+  - var type = 'shortread_9'
+
+block content
+
+  section.main
+    .container
+    
+      .populations
+        h1.populations__title
+          | Суточная потребность в магнии у беременных
+        .populations__subtitle
+          | Вопросы безопасной и эффективной коррекции ДМ у беременных
+        .populations__discriptions
+          | У беременных потребность в магнии возрастает в 2–3 раза, что связано с ростом и развитием плода, увеличением общей массы крови, высоким уровнем эстрогенов, а также увеличением массы матки и появлением и ростом плаценты (матка и плацента относятся к органам с максимальной концентрацией магния).
+          sup 1
+        .populations__banner
+          .populations__banner-left
+            p.populations__banner-text
+              | Поэтому дефицит магния у беременных встречается чаще, чем в популяции в целом.
+              sup 2
+          .populations__banner-right
+            img(src="img/shortread_9/populations_banner.png" alt="Беременная девушка")
+        .populations__discriptions
+          | Хорошо известно, что плацента синтезирует более 150 белков и гормонов, а 70% из них являются магнийзависимыми. Это является одной из основных причин повышенной потребности в магнии у беременных женщин.
+          sup 3
+          | Беременность сопровождается прогрессивным снижением уровня магния как в сыворотке крови, так и в тканях, в связи с высоким потреблением на пластические и энергетические процессы и повышением ренальной экскреции почти на 25%.
+          sup 2
+        .populations__light-blue
+          p.populations__light-blue-text
+            | Такой «физиологический» дефицит магния во время беременности в отсутствие адекватной нутриентной дотации может повышать риск ранних и поздних выкидышей, преждевременных родов, преэклампсии, задержки внутриутробного развития плода и т.п.
+            sup 2
+        
+        .populations__stats
+          .populations__stats-content
+            .populations__stats-left
+              img(src="img/shortread_9/populations_banner.png" alt="Беременная женщина")
+            .populations__stats-right
+              .populations__stats-text
+                | А распространённость гипомагниемии среди беременных по данным двух масштабных многоцентровым исследованиям: MAGIC, MAGIC 2 достигает
+              .populations__stats-number
+                .populations__stats-main 81,2%
+                .populations__stats-sub 2,4

--- a/src/magne_b6/style.scss
+++ b/src/magne_b6/style.scss
@@ -1,3 +1,4 @@
 // @use '../common.scss' as *;
 @use '_scss/layout';
 @use '_scss/index';
+@use '_scss/shortread_9';


### PR DESCRIPTION
Add a new statistics block to the `.populations` section to display research data, as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-f4bf4ece-fbb2-4a36-9f8f-274f31b9d8b1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f4bf4ece-fbb2-4a36-9f8f-274f31b9d8b1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

